### PR TITLE
changes needed for openmind/slurm

### DIFF
--- a/mit_slurm_readme.md
+++ b/mit_slurm_readme.md
@@ -1,6 +1,9 @@
 ## How to use bootstrap-fmriprep on slurm
 
 #### 1) Clone the repo
+
+- naviagte to openmind_slurm branch to use bootstrap-fmriprep on slurm as described below
+
 #### 2) navigate to TheWay/scripts/cubic/config_examples/bootstrap-fmriprep and 
 
 - edit env_setup.sh so that it will activated an environment with datalad installed

--- a/mit_slurm_readme.md
+++ b/mit_slurm_readme.md
@@ -1,0 +1,34 @@
+## How to use bootstrap-fmriprep on slurm
+
+#### 1) Clone the repo
+#### 2) navigate to TheWay/scripts/cubic/config_examples/bootstrap-fmriprep and 
+
+- edit env_setup.sh so that it will activated an environment with datalad installed
+- edit slurm_opt.txt so that it has your required slurm job specifications
+- edit fmriprep_opt.txt so that it has your required fmriprep parameters
+**if you are not using a bids filter file, remove the line "--bids-filter-file code/fmriprep_filter.json"*
+**don't need to change the freesurfer license file path, this can be specified later*
+
+
+#### 3) navigate to /TheWay/scripts/cubic and using an environment with datalad installed, run the sbatch_fmriprep.sh script, for example:
+
+    ./bootstrap-fmriprep.sh \
+    -i /om/scratch/Tue/jsmentch/merlin_fmriprep/ds001110 \
+    -t /om/scratch/Tue/jsmentch/merlin_fmriprep/working \
+    -v 21.0.1 \
+    -e /om/scratch/Tue/jsmentch/merlin_fmriprep/TheWay/scripts/cubic/config_examples/bootstrap-fmriprep/env_setup.sh \
+    -f /om/scratch/Tue/jsmentch/merlin_fmriprep/TheWay/scripts/cubic/config_examples/bootstrap-fmriprep/fmriprep_opt.txt \
+    -w /om/scratch/Tue/jsmentch/merlin_fmriprep/TheWay/scripts/cubic/config_examples/bootstrap-fmriprep/slurm_opt.txt \
+    -p /om/scratch/Tue/jsmentch/merlin_fmriprep/project_dir \
+    -s sub-* \
+    -l /om2/user/jsmentch/data/freesurfer_license.txt
+
+  **the project_dir (-p) should not exist, it will be created as a new dataset*
+  **the working directory (-t) should be an existing path*
+#### 4) navigate to your new project_dir/analysis directory
+#### 5) submit your job array to run fmriprep
+  **chmod u+x code/merge_outputs.sh if it is not executable*
+  **run from the analysis directory eg:*
+  
+      sbatch code/sbatch_array.sh
+#### 6) after the jobs finish, run ./code/merge_outputs.sh to merge the outputs

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -377,6 +377,8 @@ echo "outputsource=${output_store}#$(datalad -f '{infos[dataset][id]}' wtf -S da
 echo "cd ${PROJECTROOT}" >> code/merge_outputs.sh
 wget -qO- ${MERGE_POSTSCRIPT} >> code/merge_outputs.sh
 
+chmod +x code/merge_outputs.sh
+
 dssource="${input_store}#$(datalad -f '{infos[dataset][id]}' wtf -S dataset)"
 pushgitremote=$(git remote get-url --push output)
 

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -21,7 +21,7 @@ fi
 echo USING DATALAD VERSION ${DATALAD_VERSION}
 
 
-while getopts i:t:v:e:f:p:w:l:s: flag
+while getopts i:t:v:e:f:p:w:l:s:c: flag
 do
     case "${flag}" in
         i) BIDSINPUT=${OPTARG};;
@@ -33,6 +33,7 @@ do
         w) SLURM_OPT_FILE=${OPTARG};;
 	l) FREESURFER_LICENSE=${OPTARG};;
         s) SUBJECTS_SUBSET=${OPTARG};;
+	c) COPY_DIR=${OPTARG};;
     esac
 done
 
@@ -158,7 +159,6 @@ else
     datalad save -r -m "added input data"
 fi
 
-# dj: using subset for testing
 if [[ -z ${SUBJECTS_SUBSET} ]]
 then
     SUBJECTS=$(find inputs/data -type d -name sub-* | cut -d '/' -f 3 )
@@ -308,6 +308,14 @@ EOT
 
 chmod +x code/fmriprep_run.sh
 cp ${FREESURFER_LICENSE} code/license.txt
+
+if [[ -z ${COPY_DIR} ]]
+then
+    echo "No COPY_DIR set, nothing is copied to code/"
+else
+    cp ${COPY_DIR}/* code/
+    echo "content of ${COPY_DIR} is copied to code/"
+fi
 
 mkdir logs
 echo .SLURM_datalad_lock >> .gitignore

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -236,7 +236,7 @@ cd \${JOB_TMPDIR}
 # cd /cbica/comp_space/$(basename $HOME)
 # Used for the branch names and the temp dir
 BRANCH="job-\${job_id}-\${subid}"
-mkdir \${BRANCH}
+mkdir -p \${BRANCH}
 cd \${BRANCH}
 
 # get the analysis dataset, which includes the inputs as well

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -330,12 +330,12 @@ echo FMRIPREP_VER: ${fmriprep_version}
 echo SUBID: ${subid}
 echo PWD: ${PWD}
 echo In fmriprep_run before singularity;
-singularity run --cleanenv -B ${PWD} \
+singularity run --cleanenv -B ${PWD}:/pwd \
     containers/images/bids/bids-fmriprep--${fmriprep_version}.sing \
-    inputs/data \
-    prep \
+    /pwd/inputs/data \
+    /pwd/prep \
     participant \
-    -w ${PWD}/.git/tmp/wkdir \
+    -w /pwd/.git/tmp/wkdir \
 EOT
 
 cat ${FMRIPREP_OPT_FILE} >> code/fmriprep_run.sh

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -292,6 +292,9 @@ fi
 # TODO: Be sure the actual path to the fmriprep container is correct
 # TODO FIX path!!
 echo Before running datalad run
+if [[ -d prep/sourcedata/freesurfer ]]; then
+    find prep/sourcedata/freesurfer -name "*IsRunning*" -delete
+fi
 echo I am in \${PWD}
 datalad run \
     -i code/fmriprep_run.sh \

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -190,7 +190,7 @@ subid="\$3"
 job_id="\$4"
 echo SUBID: \${subid}
 echo TMPDIR: \${TMPDIR}
-echo TJOB_TMPDIR: \${JOB_TMPDIR}
+echo JOB_TMPDIR: \${JOB_TMPDIR}
 echo fmriprep_version: ${VERSION}
 # change into the cluster-assigned temp directory. Not done by default in SGE
 cd \${JOB_TMPDIR}

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -304,8 +304,8 @@ flock \${DSLOCKFILE} git push outputstore
 echo TMPDIR TO DELETE
 echo \${BRANCH}
 
-datalad uninstall -r --nocheck --if-dirty ignore inputs/data
-datalad drop -r . --nocheck
+#datalad uninstall -r --nocheck --if-dirty ignore inputs/data
+datalad drop -r . --reckless kill
 git annex dead here
 cd ../..
 #TODO: for now I will just move it instead of removing
@@ -429,7 +429,7 @@ datalad save -m "SLURM submission setup" code/ .gitignore
 # git operations needlessly slow
 if [ "${BIDS_INPUT_METHOD}" = "clone" ]
 then
-    datalad uninstall -r --nocheck inputs/data
+    datalad drop -r --reckless availability inputs/data
 fi
 
 # make sure the fully configured output dataset is available from the designated

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -189,10 +189,18 @@ else
     echo "LIST OF SUBJECTS": ${SUBJECTS}
 fi
 
-#dj: should we change this part?
 CONTAINERDS=///repronim/containers
 datalad install -d . --source ${CONTAINERDS}
-datalad get containers/images/bids/bids-fmriprep--${VERSION}.sing
+# amend the previous commit with a nicer commit message
+git commit --amend -m 'Register containers repo as a subdataset'
+if [[ "${VERSION}" == "fake" ]]
+then
+    cp /om2/user/djarecka/bootstrap/fake/fake_fmriprep_test_amd_latest.sif ${PROJECTROOT}/analysis/containers/images/bids/bids-fmriprep--${VERSION}.sing
+    datalad save -m "added a fake image" containers/images/bids/bids-fmriprep--${VERSION}.sing
+    echo "added a fake container"
+else
+    datalad get containers/images/bids/bids-fmriprep--${VERSION}.sing
+fi
 CONTAINERS_REPO=${PROJECTROOT}/analysis/containers
 
 cd ${PROJECTROOT}/analysis

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -344,6 +344,7 @@ cat >> code/fmriprep_run.sh << "EOT"
 cd prep
 mkdir -p ../fmriprep-${fmriprep_version}
 mv ${subid} ../fmriprep-${fmriprep_version}/
+mv ${subid}.html ../fmriprep-${fmriprep_version}/
 mkdir -p ../freesurfer-${fmriprep_version}
 mv sourcedata/freesurfer  ../freesurfer-${fmriprep_version}/
 cd ..

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -344,6 +344,7 @@ cat >> code/fmriprep_run.sh << "EOT"
 cd prep
 mv ${subid} ../${subid}_fmriprep-${fmriprep_version}
 mv sourcedata/freesurfer  ../${subid}_freesurfer-${fmriprep_version}
+cd ..
 rm -rf prep .git/tmp/wkdir
 EOT
 

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -300,7 +300,9 @@ datalad uninstall -r --nocheck --if-dirty ignore inputs/data
 datalad drop -r . --nocheck
 git annex dead here
 cd ../..
-rm -rf \${BRANCH}
+#TODO: for now I will just move it instead of removing
+# rm -rf \${BRANCH}
+mv \${BRANCH} \${BRANCH}_torm
 
 echo SUCCESS
 # job handler should clean up workspace
@@ -332,8 +334,8 @@ cat ${FMRIPREP_OPT_FILE} >> code/fmriprep_run.sh
 
 cat >> code/fmriprep_run.sh << "EOT"
 cd prep
-mv fmriprep ../${subid}_fmriprep-${fmriprep_version}
-mv freesurfer  ../${subid}_freesurfer-${fmriprep_version}
+mv ${subid} ../${subid}_fmriprep-${fmriprep_version}
+mv sourcedata/freesurfer  ../${subid}_freesurfer-${fmriprep_version}
 rm -rf prep .git/tmp/wkdir
 EOT
 

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -311,7 +311,7 @@ singularity run --cleanenv -B ${PWD} \
     inputs/data \
     prep \
     participant \
-    -w ${PWD}/.git/tmp/wkdir
+    -w ${PWD}/.git/tmp/wkdir \
 EOT
 
 cat ${FMRIPREP_OPT_FILE} >> code/fmriprep_run.sh

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -239,15 +239,15 @@ datalad get -n "inputs/data/\${subid}"
 # TODO FIX path!!
 echo Before running datalad run
 datalad run \
-    -i code/fmriprep_zip.sh \
+    -i code/fmriprep_run.sh \
     -i inputs/data/\${subid} \
     -i inputs/data/*json \
     -i containers/images/bids/bids-fmriprep--${VERSION}.sing \
     --explicit \
-    -o \${subid}_fmriprep-${VERSION}.zip \
-    -o \${subid}_freesurfer-${VERSION}.zip \
+    -o \${subid}_fmriprep-${VERSION} \
+    -o \${subid}_freesurfer-${VERSION} \
     -m "fmriprep:${VERSION} \${subid}" \
-    "bash code/fmriprep_zip.sh \${subid} ${VERSION}"
+    "bash code/fmriprep_run.sh \${subid} ${VERSION}"
 
 # file content first -- does not need a lock, no interaction with Git
 datalad push --to output-storage
@@ -269,7 +269,7 @@ EOT
 
 chmod +x code/participant_job.sh
 
-cat > code/fmriprep_zip.sh << "EOT"
+cat > code/fmriprep_run.sh << "EOT"
 #!/bin/bash
 set -e -u -x
 subid="$1"
@@ -279,7 +279,7 @@ mkdir -p ${PWD}/.git/tmp/wdir
 echo FMRIPREP_VER: ${fmriprep_version}
 echo SUBID: ${subid}
 echo PWD: ${PWD}
-echo In fmriprep_zip before singularity;
+echo In fmriprep_run before singularity;
 singularity run --cleanenv -B ${PWD} \
     containers/images/bids/bids-fmriprep--${fmriprep_version}.sing \
     inputs/data \
@@ -288,16 +288,16 @@ singularity run --cleanenv -B ${PWD} \
     -w ${PWD}/.git/tmp/wkdir \
 EOT
 
-cat ${FMRIPREP_OPT_FILE} >> code/fmriprep_zip.sh
+cat ${FMRIPREP_OPT_FILE} >> code/fmriprep_run.sh
 
-cat >> code/fmriprep_zip.sh << "EOT"
+cat >> code/fmriprep_run.sh << "EOT"
 cd prep
-7z a ../${subid}_fmriprep-${fmriprep_version}.zip fmriprep
-7z a ../${subid}_freesurfer-${fmriprep_version}.zip freesurfer
+mv fmriprep ../${subid}_fmriprep-${fmriprep_version}
+mv freesurfer  ../${subid}_freesurfer-${fmriprep_version}
 rm -rf prep .git/tmp/wkdir
 EOT
 
-chmod +x code/fmriprep_zip.sh
+chmod +x code/fmriprep_run.sh
 cp ${FREESURFER_LICENSE} code/license.txt
 
 mkdir logs

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -163,7 +163,12 @@ else
     datalad save -r -m "added input data"
 fi
 
-if [[ -z ${SUBJECTS_SUBSET} ]]
+
+if [[ -f ${SUBJECTS_SUBSET} ]]
+then
+    echo "subjects taken from a file: ${SUBJECTS_SUBSET}"
+    SUBJECTS=`cat ${SUBJECTS_SUBSET}`
+elif [[ -z ${SUBJECTS_SUBSET} ]]
 then
     SUBJECTS=$(find inputs/data -type d -name sub-* | cut -d '/' -f 3 )
 else

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -285,7 +285,7 @@ datalad clone "\${dssource}" ds
 #setup before fmriprep run complete, make a file for requeuing
     touch ../../\${BRANCH}.exists
 else
-    cd cd \${BRANCH}/ds
+    cd \${BRANCH}/ds
 fi
 
 # ------------------------------------------------------------------------------
@@ -353,7 +353,10 @@ cat >> code/fmriprep_run.sh << "EOT"
 cd prep
 mkdir -p ../fmriprep-${fmriprep_version}
 mv ${subid} ../fmriprep-${fmriprep_version}/
-mv ${subid}.html ../fmriprep-${fmriprep_version}/
+
+if [ -f ${subid}.html ]; then
+    mv ${subid}.html ../fmriprep-${fmriprep_version}/
+fi
 mkdir -p ../freesurfer-${fmriprep_version}
 mv sourcedata/freesurfer  ../freesurfer-${fmriprep_version}/
 cd ..

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -21,17 +21,18 @@ fi
 echo USING DATALAD VERSION ${DATALAD_VERSION}
 
 
-while getopts i:t:v:p:f:o:s:l: flag
+while getopts i:t:v:e:f:p:w:l:s: flag
 do
     case "${flag}" in
         i) BIDSINPUT=${OPTARG};;
         t) JOB_TMPDIR=${OPTARG};;
         v) VERSION=${OPTARG};;
-        p) PRESCRIPT=${OPTARG};;
+        e) PRESCRIPT=${OPTARG};;
         f) FMRIPREP_OPT_FILE=${OPTARG};;
-        o) PROJECTROOT=${OPTARG};;
-        s) SLURM_OPT_FILE=${OPTARG};;
+        p) PROJECTROOT=${OPTARG};;
+        w) SLURM_OPT_FILE=${OPTARG};;
 	l) FREESURFER_LICENSE=${OPTARG};;
+        s) SUBJECTS_SUBSET=${OPTARG};;
     esac
 done
 
@@ -158,11 +159,19 @@ else
 fi
 
 # dj: using subset for testing
-SUBJECTS=$(find inputs/data -type d -name 'sub-NDARZZ*' | cut -d '/' -f 3 )
+if [[ -z ${SUBJECTS_SUBSET} ]]
+then
+    SUBJECTS=$(find inputs/data -type d -name sub-* | cut -d '/' -f 3 )
+else
+    SUBJECTS=$(find inputs/data -type d -name ${SUBJECTS_SUBSET} | cut -d '/' -f 3 )
+fi
+
 if [ -z "${SUBJECTS}" ]
 then
     echo "No subjects found in input data"
-    # exit 1
+    exit 1
+else
+    echo "LIST OF SUBJECTS": ${SUBJECTS}
 fi
 
 #dj: should we change this part?

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -291,8 +291,8 @@ datalad run \
     -i "inputs/data/*json" \
     -i containers/images/bids/bids-fmriprep--${VERSION}.sing \
     --explicit \
-    -o \${subid}_fmriprep-${VERSION} \
-    -o \${subid}_freesurfer-${VERSION} \
+    -o \fmriprep-${VERSION} \
+    -o \freesurfer-${VERSION} \
     -m "fmriprep:${VERSION} \${subid}" \
     "bash code/fmriprep_run.sh \${subid} ${VERSION}"
 
@@ -347,7 +347,8 @@ mv ${subid} ../fmriprep-${fmriprep_version}/
 mkdir -p ../freesurfer-${fmriprep_version}
 mv sourcedata/freesurfer  ../freesurfer-${fmriprep_version}/
 cd ..
-rm -rf prep .git/tmp/wkdir
+#rm -rf prep .git/tmp/wkdir
+mv prep prep_torm
 EOT
 
 chmod +x code/fmriprep_run.sh

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -342,8 +342,10 @@ cat ${FMRIPREP_OPT_FILE} >> code/fmriprep_run.sh
 
 cat >> code/fmriprep_run.sh << "EOT"
 cd prep
-mv ${subid} ../${subid}_fmriprep-${fmriprep_version}
-mv sourcedata/freesurfer  ../${subid}_freesurfer-${fmriprep_version}
+mkdir -p ../fmriprep-${fmriprep_version}
+mv ${subid} ../fmriprep-${fmriprep_version}/
+mkdir -p ../freesurfer-${fmriprep_version}
+mv sourcedata/freesurfer  ../freesurfer-${fmriprep_version}/
 cd ..
 rm -rf prep .git/tmp/wkdir
 EOT

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -23,7 +23,7 @@ set -e -u
 
 
 ## Set up the directory that will contain the necessary directories
-PROJECTROOT=${PWD}/fmriprep_dec20
+PROJECTROOT=${PWD}/fmriprep_dec21a
 if [[ -d ${PROJECTROOT} ]]
 then
     echo ${PROJECTROOT} already exists
@@ -44,6 +44,15 @@ then
     echo "Required argument is an identifier of the BIDS source"
     # exit 1
 fi
+
+## Check the BIDS input
+TMPDIR=$2
+if [[ -z ${TMPDIR} ]]
+then
+    echo "Second required argument is TMPDIR"
+    # exit 1
+fi
+
 
 # Is it a directory on the filesystem?
 BIDS_INPUT_METHOD=clone
@@ -113,8 +122,7 @@ cat > code/participant_job.sh << "EOT"
 # Set up the correct conda environment
 
 module load openmind/singularity/3.5.0
-echo SINGULARITY `singularity --help`
-source ${CONDA_PREFIX}/bin/activate datalad
+source ${CONDA_EXE///conda//activate} datalad
 
 echo I\'m in $PWD using `which python`
 # fail whenever something is fishy, use -x to get verbose logfiles
@@ -276,7 +284,7 @@ cat > code/sbatch_array.sh <<EOF
 #SBATCH --output=logs/array_%A_%a.out
 #SBATCH --error=logs/array_%A_%a.err
 
-#SBATCH --export=DSLOCKFILE=${PROJECTROOT}/analysis/.SLURM_datalad_lock,CONDA_PREFIX=/om2/user/djarecka/miniconda,TMPDIR=/om2/scratch/Thu/djarecka/bootstrap
+#SBATCH --export=DSLOCKFILE=${PROJECTROOT}/analysis/.SLURM_datalad_lock,CONDA_EXE=${CONDA_EXE},TMPDIR=${TMPDIR}
 
 #SBATCH --array=0-1
 

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -108,6 +108,10 @@ then
 fi
 echo "freesurfer license file: $FREESURFER_LICENSE"
 
+if [[ -z ${COPY_DIR} ]]
+then
+    COPY_DIR=none
+fi
 
 set -e -u
 
@@ -309,7 +313,7 @@ EOT
 chmod +x code/fmriprep_run.sh
 cp ${FREESURFER_LICENSE} code/license.txt
 
-if [[ -z ${COPY_DIR} ]]
+if [[ "${COPY_DIR}" == "none" ]]
 then
     echo "No COPY_DIR set, nothing is copied to code/"
 else

--- a/scripts/cubic/bootstrap-fmriprep.sh
+++ b/scripts/cubic/bootstrap-fmriprep.sh
@@ -399,8 +399,8 @@ echo logs >> .gitignore
 datalad save -m "Participant compute job implementation"
 
 # Add a script for merging outputs
-# dj: not used
-MERGE_POSTSCRIPT=https://raw.githubusercontent.com/PennLINC/TheWay/main/scripts/cubic/merge_outputs_postscript.sh
+MERGE_POSTSCRIPT=https://raw.githubusercontent.com/djarecka/TheWay/openmind_slurm/scripts/cubic/merge_outputs_postscript.sh
+
 cat > code/merge_outputs.sh << "EOT"
 #!/bin/bash
 PS4=+

--- a/scripts/cubic/config_examples/bootstrap-fmriprep/copy_code/fmriprep_filter.json
+++ b/scripts/cubic/config_examples/bootstrap-fmriprep/copy_code/fmriprep_filter.json
@@ -1,0 +1,6 @@
+{
+    "bold": {
+	"datatype": "func",
+	"suffix": "bold"
+	}
+}

--- a/scripts/cubic/config_examples/bootstrap-fmriprep/env_setup.sh
+++ b/scripts/cubic/config_examples/bootstrap-fmriprep/env_setup.sh
@@ -1,0 +1,4 @@
+# Set up the correct conda environment
+module load openmind/singularity/3.5.0
+# assumin that there is a conda environment named datalad
+source /om2/user/djarecka/miniconda/bin/activate datalad                                                                                    

--- a/scripts/cubic/config_examples/bootstrap-fmriprep/fmriprep_opt.txt
+++ b/scripts/cubic/config_examples/bootstrap-fmriprep/fmriprep_opt.txt
@@ -1,0 +1,9 @@
+    --n_cpus 1 \
+    --stop-on-first-crash \
+    --fs-license-file code/license.txt \
+    --skip-bids-validation \
+    --use-aroma \
+    --output-spaces MNI152NLin6Asym:res-2 anat \
+    --participant-label "$subid" \
+    --force-bbr \
+    --cifti-output 91k -v -v

--- a/scripts/cubic/config_examples/bootstrap-fmriprep/fmriprep_opt.txt
+++ b/scripts/cubic/config_examples/bootstrap-fmriprep/fmriprep_opt.txt
@@ -6,4 +6,5 @@
     --output-spaces MNI152NLin6Asym:res-2 anat \
     --participant-label "$subid" \
     --force-bbr \
-    --cifti-output 91k -v -v
+    --cifti-output 91k -v -v \
+    --bids-filter-file code/fmriprep_filter.json

--- a/scripts/cubic/config_examples/bootstrap-fmriprep/slurm_opt.txt
+++ b/scripts/cubic/config_examples/bootstrap-fmriprep/slurm_opt.txt
@@ -1,0 +1,6 @@
+#SBATCH --job-name=fp_test
+#SBATCH --partition=gablab
+#SBATCH --time=48:00:00
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem-per-cpu=8G

--- a/scripts/cubic/merge_outputs_postscript.sh
+++ b/scripts/cubic/merge_outputs_postscript.sh
@@ -2,19 +2,19 @@
 # The following should be pasted into the merge_outputs.sh script
 datalad clone ${outputsource} merge_ds
 cd merge_ds
-NBRANCHES=$(git branch -a | grep job- | sort | wc -l)
+NBRANCHES=$(git branch -a | grep sub- | sort | wc -l)
 echo "Found $NBRANCHES branches to merge"
 
 gitref=$(git show-ref master | cut -d ' ' -f1 | head -n 1)
 
 # query all branches for the most recent commit and check if it is identical.
 # Write all branch identifiers for jobs without outputs into a file.
-for i in $(git branch -a | grep job- | sort); do [ x"$(git show-ref $i \
+for i in $(git branch -a | grep sub- | sort); do [ x"$(git show-ref $i \
   | cut -d ' ' -f1)" = x"${gitref}" ] && \
   echo $i; done | tee code/noresults.txt | wc -l
 
 
-for i in $(git branch -a | grep job- | sort); \
+for i in $(git branch -a | grep sub- | sort); \
   do [ x"$(git show-ref $i  \
      | cut -d ' ' -f1)" != x"${gitref}" ] && \
      echo $i; \


### PR DESCRIPTION
In addition the changes I made before Friday, I made some changes we discussed: 

- I've moved the data to /om/scratch (right now /om2/scratch/Sat/djarecka/bootstrap/inputs_data/HBN_BIDS)
- removed the TMPDIR setting, just using default slurm tmpdirs

I also made some changes that were irrelevant right now in order to bring the code closer to the current version of the code from the Penn repo. However, I decided to leave the fmriprep arguments as it was in the Steve&Jeff script.

I've just started a longer run, logs can be found: `/om2/user/djarecka/bootstrap/fmriprep_dec15f/analysis/logs/array_22480069_*`


fyi. - I've tried to change the image to 21.0.0, but I'm getting some errors, will try to check more tomorrow (you can see `/om2/user/djarecka/bootstrap/fmriprep_dec15e/analysis/logs/array_22477137_0.err`)
